### PR TITLE
Changing the master-slave terminology

### DIFF
--- a/blank_lastrun.py
+++ b/blank_lastrun.py
@@ -40,7 +40,7 @@ filename = _thisDir + os.sep + u'data/%s_%s_%s' % (expInfo['participant'], expNa
 # An ExperimentHandler isn't essential but helps with data saving
 thisExp = data.ExperimentHandler(name=expName, version='',
     extraInfo=expInfo, runtimeInfo=None,
-    originPath=u'C:\\Users\\omada\\Downloads\\two_choice-master\\two_choice-master\\blank.psyexp',
+    originPath=u'C:\\Users\\omada\\Downloads\\two_choice-main\\two_choice-main\\blank.psyexp',
     savePickle=True, saveWideText=True,
     dataFileName=filename)
 # save a log file for detail verbose info

--- a/pumps/__init__.py
+++ b/pumps/__init__.py
@@ -2,7 +2,7 @@
 # Implementation is designed to be modular to enable operation of pumps
 # from a variety of manufacturers.
 # 
-# Based on pumps.m master/slave interface for Matlab by ...
+# Based on pumps.m main/subordinate interface for Matlab by ...
 # Lloyd Ung
 #
 # Author: Wolfgang M. Pauli


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.